### PR TITLE
fix(rights): Add missing chmod

### DIFF
--- a/betterlockscreen.sh
+++ b/betterlockscreen.sh
@@ -70,6 +70,7 @@ if [[ -f /usr/bin/betterlockscreen ]]; then
 fi
 curl -o script https://raw.githubusercontent.com/pavanjadhaw/betterlockscreen/master/betterlockscreen;
 sudo cp script /usr/bin/betterlockscreen;
+sudo chmod +x /usr/bin/betterlockscreen;
 rm script;
 
 printf -- "\n----------------------------------------------------------------------------------------------------";


### PR DESCRIPTION
Used to allow betterlockscreen to be called via command line because by default executable comes with no rights to be executed.